### PR TITLE
libcef fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,21 @@ RUN nuget restore IronPdfDockerTest.sln
 COPY . ./
 RUN msbuild IronPdfDockerTest.sln /p:Configuration=Release
 
+FROM mcr.microsoft.com/windows:1809 as dll-source
+
 # docker tag registry.cloud.insitehq.net/commerce-windows/runtime-base
 FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019 as runtime
 
 ENV chocolateyUseWindowsCompression 'false'
 RUN ["powershell", "-Command", "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; [Net.ServicePointManager]::SecurityProtocol; iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex"]
 RUN choco feature enable -n allowGlobalConfirmation; choco feature disable -n=showDownloadProgress
-RUN #choco install vcredist140; choco install openssh
+RUN choco install vcredist140; choco install openssh
+
+COPY --from=dll-source c:/windows/system32/dxva2.dll \
+                       c:/windows/system32/mf.dll \
+                       c:/windows/system32/mfplat.dll \
+                       c:/windows/system32/mfreadwrite.dll \
+                       c:/windows/system32/
 
 WORKDIR C:/LogMonitor
 COPY ./LogMonitor/. ./

--- a/README.md
+++ b/README.md
@@ -61,3 +61,19 @@ To learn how to solve this issue please read https://iron.helpscoutdocs.com/arti
 [2022-07-06 09:48:57] Attempting NuGet package 'IronPdf.Native.Chrome' deployment using 'IronPdf.Native.Chrome.Windows(2022.5.5590)'
 [2022-07-06 09:48:57] Downloading NuGet package from 'https://www.nuget.org/api/v2/package/IronPdf.Native.Chrome.Windows/2022.5.5590'
 ```
+
+
+Notes:
+Using Dependencies (https://github.com/lucasg/Dependencies) diagnosed dependencies of libcef.dll on local system vs container
+* ps> .\Dependencies.exe "C:\inetpub\wwwroot\bin\runtimes\win-x64\native\libcef.dll" -modules -depth 1
+* returned the following:
+```
+[NOT_FOUND] MF.dll :
+[NOT_FOUND] MFReadWrite.dll :
+[NOT_FOUND] MFPlat.DLL :
+[NOT_FOUND] dxva2.dll :
+[NOT_FOUND] bthprops.cpl :
+[NOT_FOUND] BluetoothApis.dll :
+```
+* Found references to first 4 being part of Media Feature pack (https://support.microsoft.com/en-us/topic/media-feature-pack-list-for-windows-n-editions-c1c6fffa-d052-8338-7a79-a4bb980a700a)
+* unable to grok install on container but found github example for extraction from base image (https://github.com/game-ci/docker/blob/163f9c2e99b90a5129b62bdaf3620c1b257c51e6/images/windows/base/Dockerfile)


### PR DESCRIPTION
Update docker to pull dlls from base image instead of local machine
Add notes to readme.md
Still testing, but it seems like it's still not generating a pdf in container - playing with logging still